### PR TITLE
Add N-th match macro support.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
 
+## 0.2.0 (December 20, 2020)
+- Add N-th match macro support.
+
 ## 0.1.0 (November 21, 2020)
 - Initial version.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ The following tokens are replaced in the filename template:
 - `[ext]` the input extension of the bundle,
 - `[name]` the basename of the bundle,
 - `[type]` the output type of the bundle,
-- `[hash]` the hash of the bundle.
+- `[hash]` the hash of the bundle,
+- `[N]` the N-th match obtained from matching the current filename against the Regular Expression.
 
 ### Examples
 ```


### PR DESCRIPTION
## This Pull Request:
- Adds N-th match macro support.

## Why is this PR needed?
- Arbitrary regex matches are useful to replace only part of a path / filename.