### PR TITLE
Fix package name in installation guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 1. `$ npm install parcel-namer-custom --save-dev`
 2. Update your `.parcelrc` with the entry below.
    ```
-   "namers": ["parcel-namer-rewrite", "..."],
+   "namers": ["parcel-namer-custom", "..."],
    ```
 
 *Important:* the three dots indicate to Parcel to run their default namer on any bundles that haven't been named yet.


### PR DESCRIPTION
I've found a typo in your installation guide. The name used is different from the real package name.

Thanks for your work and for creating this package.