### PR TITLE
fixed load package.json error

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -37,7 +37,7 @@ export default new Namer({
     }
 
     const { filePath: bundlePath } = bundle.getMainEntry();
-    const { projectRoot } = options;
+    const projectRoot = process.cwd();
     const pluginConfig = await getPluginConfig(projectRoot);
 
     // Walk through matchers until first hit, top to bottom.


### PR DESCRIPTION
fixed loadthe package.json from %USERPROFILE% on windows 10;   use `process.cwd()` to get the correct project root folder path