### PR TITLE
Environment variable `PARCEL_NAMER_CUSTOM_STAGE` to change the key used in `package.json`

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ The following tokens are replaced in the filename template:
 // src/modules/main.jsx -> scripts/main.9488dd.js
 ```
 
+If the environment variable `PARCEL_NAMER_CUSTOM_STAGE=deploy` is set, `parcel-namer-custom:deploy` object prop will loaded.
+
 ## Debugging
 Run Parcel with `--log-level info` to see what bundles are renamed.
 

--- a/src/index.js
+++ b/src/index.js
@@ -12,6 +12,8 @@ import { Namer } from '@parcel/plugin';
 // Local modules.
 import { name as pluginName } from '../package.json';
 
+const pkgConfigKey = process.env.PARCEL_NAMER_CUSTOM_STAGE ? `${pluginName}:${process.env.PARCEL_NAMER_CUSTOM_STAGE}` : pluginName;
+
 // Plugin configuration importer.
 let projectPackagePromise = null;
 const getPluginConfig = (projectRoot) => {
@@ -19,7 +21,7 @@ const getPluginConfig = (projectRoot) => {
   if (projectPackagePromise == null) {
     projectPackagePromise = import(joinPath(projectRoot, 'package.json'))
       .then((pkgConfig) => Object
-        .entries(pkgConfig[pluginName] || {})
+        .entries(pkgConfig[pkgConfigKey] || {})
         .map(([srcPattern, destPattern]) => ([
           new RegExp(srcPattern, 'i'),
           destPattern,


### PR DESCRIPTION
# This Pull Request:
Environment variable `PARCEL_NAMER_CUSTOM_STAGE` to change the key used in `package.json`

If the environment variable `PARCEL_NAMER_CUSTOM_STAGE=deploy` is set, `parcel-namer-custom:deploy` object prop will loaded.


# Why is this PR needed?
Example: `[hash]` is not added during development, but can be added during deployment.

```json
{
  "scripts" {
    "start": "parcel",
    "build": "parcel build",
    "build:deploy": "PARCEL_NAMER_CUSTOM_STAGE=deploy parcel build"
  },
  "parcel-namer-custom": {
    ".scss$": "[folder]/[name].[type]",
    ".jsx?$": "scripts/[name].[type]"
  },
  "parcel-namer-custom:deploy": {
    ".scss$": "[folder]/[name].[hash].[type]",
    ".jsx?$": "scripts/[name].[hash].[type]"
  }
}
```

